### PR TITLE
New pwm subsystem supporting centralized pwm resource coordination

### DIFF
--- a/src/drivers/rgbled_pwm/rgbled_pwm.cpp
+++ b/src/drivers/rgbled_pwm/rgbled_pwm.cpp
@@ -157,6 +157,7 @@ RGBLED_PWM::init()
     _default_rate = 50;
     _alt_rate = 400;
     _working_rate = PWM_GROUP_RATE_UNSPECIFIED;
+    _channel_rate_map = _working_channel_map;
     
     if (register_working_channels()!=OK) {
         printf("fail to register rgb led\n");

--- a/src/lib/pwmgroups/pwmgroups.h
+++ b/src/lib/pwmgroups/pwmgroups.h
@@ -119,6 +119,7 @@
 typedef enum {
     PWM_GROUP_RATE_ALT,
     PWM_GROUP_RATE_DEFAULT,
+    PWM_GROUP_RATE_MIXED,
     PWM_GROUP_RATE_UNSPECIFIED
 } pwm_groups_rate_t;
 
@@ -224,8 +225,12 @@ protected:
     //group channels must be continously allocated;
     uint32_t _group_channel_map;
     uint32_t _working_channel_map;
-    //map of channels with alt rate;
+    //map of channels with alt rate, different from _working_channel_map in some cases,
+    //e.g., a mixer group includes both main output and camera trigger;
     uint32_t _channel_rate_map;
+    
+    //channel map for capture function;
+    uint32_t _capture_channel_map;
     
     uint8_t _timer_map_offset;
     uint32_t _channel_map_offset;


### PR DESCRIPTION
**New features introduces by this new pwm subsystem:**

1. Real support of 8 main + 8 aux channels on a single FMU chip.
2. Global pwm resource manifest and allocation through board's timer_config.c. 
3. Centralized pwm resource (timers/channels) management and coordination. 
4. New model for all pwm devices. Added abstraction layer of PWM groups. Each pwm device is one or         more groups, other than previous pwm port based operations. FMU is one type of PWM devices.
5. Runtime, flexible pwm channels allocation thus pwm devices can use arbitrary idle channels, rather than hard coded on fixed channels.
6. Unified MindPX and new MindRacer hardware into one firmware target.
    MindPX: 8 Main + 8 AUX
    New MindRacer: 8 Main + 5 AUX